### PR TITLE
Add findSubfolders tests and export function

### DIFF
--- a/indexer.js
+++ b/indexer.js
@@ -9,12 +9,6 @@
 const fs = require('fs').promises;
 const path = require('path');
 
-// --- CONFIGURATION ---
-// !!! IMPORTANT: Replace this with the full path to the folder you want to index.
-const folderToIndexPath = '/Users/ricardo/Library/CloudStorage/GoogleDrive-ricardo.rplazas@gmail.com'; 
-const MAX_DEPTH = 5; // The maximum number of subfolder levels to scan.
-// !!!!!!!!!!!!!!!!!!!!!
-
 /**
  * Recursively finds subfolders up to a specified depth.
  * @param {string} currentPath The directory to start scanning from.
@@ -43,28 +37,37 @@ async function findSubfolders(currentPath, subfolders, currentDepth, maxDepth) {
         // console.error(`Could not read directory: ${currentPath}`);
     }
 }
+module.exports = { findSubfolders };
 
-async function main() {
-    if (folderToIndexPath === '/path/to/your/test/folder') {
-        console.error("Please update the `folderToIndexPath` variable in this script with the folder you want to test.");
-        return;
+if (require.main === module) {
+    // --- CONFIGURATION ---
+    // !!! IMPORTANT: Replace this with the full path to the folder you want to index.
+    const folderToIndexPath = '/Users/ricardo/Library/CloudStorage/GoogleDrive-ricardo.rplazas@gmail.com';
+    const MAX_DEPTH = 5; // The maximum number of subfolder levels to scan.
+    // !!!!!!!!!!!!!!!!!!!!!
+
+    async function main() {
+        if (folderToIndexPath === '/path/to/your/test/folder') {
+            console.error("Please update the `folderToIndexPath` variable in this script with the folder you want to test.");
+            return;
+        }
+
+        console.log(`Starting to index folder: ${folderToIndexPath} (up to ${MAX_DEPTH} levels deep)`);
+        const startTime = process.hrtime();
+
+        const subfolders = [];
+        // Start the initial scan at depth 0.
+        await findSubfolders(folderToIndexPath, subfolders, 0, MAX_DEPTH);
+
+        const endTime = process.hrtime(startTime);
+        const durationInMs = (endTime[0] * 1000 + endTime[1] / 1e6).toFixed(2);
+
+        console.log(`\n--- Indexing Complete ---`);
+        console.log(`Found ${subfolders.length} subfolders within ${MAX_DEPTH} levels.`);
+        console.log(`Time taken: ${durationInMs} ms`);
+        console.log('\nFound folders:');
+        console.log(subfolders);
     }
 
-    console.log(`Starting to index folder: ${folderToIndexPath} (up to ${MAX_DEPTH} levels deep)`);
-    const startTime = process.hrtime();
-    
-    const subfolders = [];
-    // Start the initial scan at depth 0.
-    await findSubfolders(folderToIndexPath, subfolders, 0, MAX_DEPTH);
-    
-    const endTime = process.hrtime(startTime);
-    const durationInMs = (endTime[0] * 1000 + endTime[1] / 1e6).toFixed(2);
-
-    console.log(`\n--- Indexing Complete ---`);
-    console.log(`Found ${subfolders.length} subfolders within ${MAX_DEPTH} levels.`);
-    console.log(`Time taken: ${durationInMs} ms`);
-    console.log('\nFound folders:');
-    console.log(subfolders);
+    main();
 }
-
-main();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron-forge start",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "package": "electron-forge package",
     "make": "electron-forge make"
   },
@@ -22,7 +22,8 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.8.2",
     "@electron-forge/plugin-fuses": "^7.8.2",
     "@electron/fuses": "^1.8.0",
-    "electron": "^37.2.4"
+    "electron": "^37.2.4",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",

--- a/tests/indexer.test.js
+++ b/tests/indexer.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const { findSubfolders } = require('../indexer');
+
+describe('findSubfolders', () => {
+  let baseDir;
+
+  beforeEach(async () => {
+    baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'findSubfolders-'));
+    await fs.mkdir(path.join(baseDir, 'a', 'a1'), { recursive: true });
+    await fs.mkdir(path.join(baseDir, 'a', 'a2'), { recursive: true });
+    await fs.mkdir(path.join(baseDir, 'b', 'b1', 'b1a'), { recursive: true });
+    await fs.mkdir(path.join(baseDir, 'c', 'c1'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  test('returns directories up to specified depth', async () => {
+    const subfolders = [];
+    await findSubfolders(baseDir, subfolders, 0, 2);
+    const relative = subfolders.map(p => path.relative(baseDir, p));
+    expect(new Set(relative)).toEqual(new Set([
+      'a',
+      'b',
+      'c',
+      path.join('a', 'a1'),
+      path.join('a', 'a2'),
+      path.join('b', 'b1'),
+      path.join('c', 'c1')
+    ]));
+  });
+
+  test('handles inaccessible folder gracefully', async () => {
+    const subfolders = [];
+    const originalReaddir = fs.readdir;
+    const inaccessible = path.join(baseDir, 'c');
+    const readdirSpy = jest.spyOn(fs, 'readdir').mockImplementation(async (p, opts) => {
+      if (p === inaccessible) {
+        const err = new Error('EACCES');
+        err.code = 'EACCES';
+        throw err;
+      }
+      return originalReaddir.call(fs, p, opts);
+    });
+
+    await findSubfolders(baseDir, subfolders, 0, 2);
+    readdirSpy.mockRestore();
+    const relative = subfolders.map(p => path.relative(baseDir, p));
+    expect(relative).toContain('c');
+    expect(relative).not.toContain(path.join('c', 'c1'));
+  });
+});


### PR DESCRIPTION
## Summary
- export `findSubfolders` and guard main script execution
- add Jest tests for directory depth limiting and error handling
- wire up Jest in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b02884608333bc7b83447ef41d9f